### PR TITLE
specialize `tensor_product` for `OneToOne`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/tensor_product.jl
+++ b/src/tensor_product.jl
@@ -28,4 +28,7 @@ function tensor_product(a1::AbstractUnitRange, a2::AbstractUnitRange)
   return Base.OneTo(length(a1) * length(a2))
 end
 
+# OneToOne acts as neutral element for tensor_product
 tensor_product(::OneToOne, ::OneToOne) = OneToOne()
+tensor_product(::OneToOne, a::AbstractUnitRange) = tensor_product(a)
+tensor_product(a::AbstractUnitRange, ::OneToOne) = tensor_product(a)

--- a/test/test_tensor_product.jl
+++ b/test/test_tensor_product.jl
@@ -15,6 +15,8 @@ b1 = blockedrange([1, 2])
 
   @test ⊗(r0, r0) isa OneToOne
   @test blockisequal(⊗(b1, b1), blockedrange([1, 2, 2, 4]))
+  @test blockisequal(⊗(b1, r0), b1)
+  @test blockisequal(⊗(r0, b1), b1)
 end
 
 @testset "tensor_product" begin


### PR DESCRIPTION
Have `OneToOne` as a neutral element for `tensor_product`. It should in particular preserve block structure and labels.