### PR TITLE
`⊗` as tensor_product alias

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/tensor_product.jl
+++ b/src/tensor_product.jl
@@ -9,15 +9,6 @@ function require_one_based_axis(a::AbstractUnitRange)
 end
 
 # ==============================  tensor product  ==========================================
-⊗() = tensor_product()
-⊗(a) = tensor_product(a)
-
-# default. No type restriction to allow sectors as input
-⊗(a1, a2) = tensor_product(a1, a2)
-
-# allow to specialize ⊗(a1, a2) to fusion_product
-⊗(a1, a2, as...) = ⊗(⊗(a1, a2), as...)
-
 tensor_product() = OneToOne()
 tensor_product(a) = a
 tensor_product(a1, a2, as...) = tensor_product(tensor_product(a1, a2), as...)
@@ -32,3 +23,5 @@ end
 tensor_product(::OneToOne, ::OneToOne) = OneToOne()
 tensor_product(::OneToOne, a::AbstractUnitRange) = tensor_product(a)
 tensor_product(a::AbstractUnitRange, ::OneToOne) = tensor_product(a)
+
+const ⊗ = tensor_product

--- a/src/tensor_product.jl
+++ b/src/tensor_product.jl
@@ -28,4 +28,7 @@ function tensor_product(a1::AbstractUnitRange, a2::AbstractUnitRange)
   return Base.OneTo(length(a1) * length(a2))
 end
 
+# OneToOne acts as neutral element for tensor_product
 tensor_product(::OneToOne, ::OneToOne) = OneToOne()
+tensor_product(::OneToOne, a::AbstractUnitRange) = tensor_product(a)
+tensor_product(a::AbstractUnitRange, ::OneToOne) = tensor_product(a)

--- a/test/test_tensor_product.jl
+++ b/test/test_tensor_product.jl
@@ -15,6 +15,8 @@ b1 = blockedrange([1, 2])
 
   @test ⊗(r0, r0) isa OneToOne
   @test blockisequal(⊗(b1, b1), blockedrange([1, 2, 2, 4]))
+  @test blockisequal(⊗(b1, r0), b1)
+  @test blockisequal(⊗(r0, b1), b1)
 end
 
 @testset "tensor_product" begin

--- a/test/test_tensor_product.jl
+++ b/test/test_tensor_product.jl
@@ -7,18 +7,6 @@ using BlockArrays: blockedrange, blockisequal
 r0 = OneToOne()
 b1 = blockedrange([1, 2])
 
-@testset "⊗" begin
-  @test ⊗() isa OneToOne
-  @test ⊗(1:2) == 1:2
-  @test ⊗(1:2, 1:3) == 1:6
-  @test ⊗(1:2, 1:3, 1:4) == 1:24
-
-  @test ⊗(r0, r0) isa OneToOne
-  @test blockisequal(⊗(b1, b1), blockedrange([1, 2, 2, 4]))
-  @test blockisequal(⊗(b1, r0), b1)
-  @test blockisequal(⊗(r0, b1), b1)
-end
-
 @testset "tensor_product" begin
   @test tensor_product() isa OneToOne
   @test tensor_product(1:2) == 1:2
@@ -30,5 +18,11 @@ end
   @test_throws ArgumentError tensor_product(2:3, 2:2)
 
   @test tensor_product(r0, r0) isa OneToOne
+  @test blockisequal(tensor_product(b1, r0), b1)
+  @test blockisequal(tensor_product(r0, b1), b1)
+
   @test blockisequal(tensor_product(b1, b1), blockedrange([1, 2, 2, 4]))
+  @test blockisequal(tensor_product(b1, b1), blockedrange([1, 2, 2, 4]))
+
+  @test ⊗(r0, r0) isa OneToOne
 end


### PR DESCRIPTION
As explained in https://github.com/ITensor/GradedUnitRanges.jl/pull/24, 

This PR changes `⊗` to be an alias for `tensor_product`. 