### PR TITLE
reshape(::OneToOne)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorProducts"
 uuid = "decf83d6-1968-43f4-96dc-fdb3fe15fc6d"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/onetoone.jl
+++ b/src/onetoone.jl
@@ -6,12 +6,5 @@ OneToOne() = OneToOne{Int}()
 Base.first(a::OneToOne) = one(eltype(a))
 Base.last(a::OneToOne) = one(eltype(a))
 
+# impose Int64 to keep Base.to_shape(::Base.OneTo) convention
 Base.to_shape(::OneToOne) = 1
-
-# extend Base.OneTo behavior to OneToOne
-function Base.reshape(
-  parent::AbstractArray,
-  shp::Tuple{Union{Integer,Base.OneTo,OneToOne},Vararg{Union{Integer,Base.OneTo,OneToOne}}},
-)
-  return reshape(parent, Base.to_shape(shp))
-end

--- a/src/onetoone.jl
+++ b/src/onetoone.jl
@@ -5,3 +5,13 @@ struct OneToOne{T} <: AbstractUnitRange{T} end
 OneToOne() = OneToOne{Int}()
 Base.first(a::OneToOne) = one(eltype(a))
 Base.last(a::OneToOne) = one(eltype(a))
+
+Base.to_shape(::OneToOne) = 1
+
+# extend Base.OneTo behavior to OneToOne
+function Base.reshape(
+  parent::AbstractArray,
+  shp::Tuple{Union{Integer,Base.OneTo,OneToOne},Vararg{Union{Integer,Base.OneTo,OneToOne}}},
+)
+  return reshape(parent, Base.to_shape(shp))
+end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -12,8 +12,6 @@ using TensorProducts: OneToOne
   @test length(a0) == 1
 
   @test blockaxes(OneToOne()) == (BlockRange(OneToOne()),)
-
-  @test reshape(ones(()), (OneToOne(),)) == ones((1,))
-  @test reshape(ones(()), (OneToOne(), Base.OneTo(1), 1)) == ones((1, 1, 1))
-  @test reshape(ones(()), OneToOne(), Base.OneTo(1), 1) == ones((1, 1, 1))
+  @test Base.to_shape(OneToOne()) isa Int64
+  @test Base.to_shape(OneToOne()) == 1
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -12,4 +12,8 @@ using TensorProducts: OneToOne
   @test length(a0) == 1
 
   @test blockaxes(OneToOne()) == (BlockRange(OneToOne()),)
+
+  @test reshape(ones(()), (OneToOne(),)) == ones((1,))
+  @test reshape(ones(()), (OneToOne(), Base.OneTo(1), 1)) == ones((1, 1, 1))
+  @test reshape(ones(()), OneToOne(), Base.OneTo(1), 1) == ones((1, 1, 1))
 end


### PR DESCRIPTION
This PR allows `Base.reshape` to handle `OneToOne` similarly to `Base.OneTo(1)`, to be used e.g. in `TensorAlgebra.fusedims`.